### PR TITLE
feat: document query first messages using by negative `count`

### DIFF
--- a/docs/network/api/_api.spec.yaml
+++ b/docs/network/api/_api.spec.yaml
@@ -142,8 +142,9 @@ paths:
           name: count
           schema:
             type: integer
-          description: The number of records to fetch (only for 'last' query type).
-        - in: query
+          description: |
+            The number of records to fetch (only for 'last' query type).
+            Note: If a negative number is provided, it will fetch the first messages.        - in: query
           name: fromTimestamp
           schema:
             type: integer

--- a/docs/network/api/_api.spec.yaml
+++ b/docs/network/api/_api.spec.yaml
@@ -144,7 +144,8 @@ paths:
             type: integer
           description: |
             The number of records to fetch (only for 'last' query type).
-            Note: If a negative number is provided, it will fetch the first messages.        - in: query
+            Note: If a negative number is provided, it will fetch the first messages.
+        - in: query
           name: fromTimestamp
           schema:
             type: integer


### PR DESCRIPTION
The documentation for the 'count' query parameter in the Network API has been updated. It now includes a note specifying that if a negative number is provided, it will fetch the first messages.